### PR TITLE
feat!: add support electron 41.x and drop nodejs less than 22.x COMPASS-10561

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.4.0, 12.x, 14.x, 15.x]
+        node-version: [12.4.0, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
         exclude:
           - os: windows-latest
             node-version: 12.4.0 # The node-gyp shipped with this is too old

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v6
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        electron-version: ['37.10.3', '41.1.1']
+        electron-version: ['37.10.3', '41.1.1', latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,25 +3,42 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  test-posix:
-    name: Tests
+  test-node:
+    name: Node.js ${{ matrix.node-version }} / ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [18.x, 20.x, 22.x, 24.x]
-        exclude:
-          - os: windows-latest
-            node-version: 12.4.0 # The node-gyp shipped with this is too old
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          check-latest: true
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm install
       - name: Test
         run: npm test
+
+  test-electron:
+    name: Electron ${{ matrix.electron-version }} / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        electron-version: ['37.10.3', '41.1.1']
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - name: Install Dependencies
+        run: npm install
+      - name: Install Electron and @electron/rebuild
+        run: npm install --no-save electron@${{ matrix.electron-version }} @electron/rebuild
+      - name: Rebuild against Electron headers
+        run: npx electron-rebuild

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.4.0, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         exclude:
           - os: windows-latest
             node-version: 12.4.0 # The node-gyp shipped with this is too old

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "import": "./.esm-wrapper.mjs"
   },
   "engines": {
-    "node": ">= 18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "lint": "eslint {src,test}/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "import": "./.esm-wrapper.mjs"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 18.0.0"
   },
   "scripts": {
     "lint": "eslint {src,test}/**/*.ts",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -95,7 +95,7 @@ void RunInterruptible(const FunctionCallbackInfo<Value>& args) {
 }
 
 NODE_MODULE_INIT() {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = Isolate::GetCurrent();
   exports->Set(context,
                String::NewFromUtf8(
                   isolate, "runInterruptible", NewStringType::kInternalized)


### PR DESCRIPTION
GetIsolate was marked deprecated: https://github.com/v8/v8/commit/8a011b57d8b26e9cfe1c20a2ef26adb14be6ecc2

And is no longer present in electron headers