### PR TITLE
fix: remove dependence on bindings COMPASS-10561

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,4 @@
+'use strict';
+module.exports = {
+  'node-option': ['experimental-strip-types']
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint {src,test}/**/*.ts",
     "test": "npm run lint && npm run build && nyc npm run test-only",
     "test-nolint": "npm run build && npm run test-only",
-    "test-only": "mocha --colors -r ts-node/register test/*.ts",
+    "test-only": "NODE_OPTIONS=--experimental-strip-types mocha --colors test/*.ts",
     "build": "node-gyp rebuild && npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepack": "npm run build",
     "compile-ts": "tsc -p tsconfig.json"
@@ -35,8 +35,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/mocha": "^8.0.3",
-    "@types/node": "^14.11.1",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^25.5.2",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "eslint": "^7.9.0",
@@ -47,13 +47,8 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "gen-esm-wrapper": "^1.1.0",
-    "mocha": "^8.1.3",
-    "node-fetch": "^2.6.1",
+    "mocha": "^11.7.5",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
-  },
-  "dependencies": {
-    "bindings": "^1.5.0"
+    "typescript": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint {src,test}/**/*.ts",
     "test": "npm run lint && npm run build && nyc npm run test-only",
     "test-nolint": "npm run build && npm run test-only",
-    "test-only": "NODE_OPTIONS=--experimental-strip-types mocha --colors test/*.ts",
+    "test-only": "mocha --colors test/*.ts",
     "build": "node-gyp rebuild && npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepack": "npm run build",
     "compile-ts": "tsc -p tsconfig.json"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,19 @@
-import bindings from 'bindings';
-const native = bindings('interruptor');
+function load() {
+  try {
+    return require('../build/Release/interruptor.node');
+  } catch {
+    // Webpack will fail when just returning the require, so we need to wrap in a try/catch and rethrow.
+    /* eslint no-useless-catch: 0 */
+    try {
+      return require('../build/Debug/interruptor.node');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+const native = load();
+
 export type InterruptHandle = { __id: number };
 
 export function runInterruptible<Ret>(

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,9 @@
 import assert from 'assert';
 import { Worker } from 'worker_threads';
-import { runInterruptible, interrupt, InterruptHandle } from '../';
+import { createRequire } from 'module';
+import { runInterruptible, interrupt, type InterruptHandle } from '../lib/index.js';
+
+const require = createRequire(import.meta.url);
 
 describe('runInterruptible', () => {
   it('can interrupt itself', () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "../",
+        "module": "nodenext",
+        "noEmit": true,
+        "erasableSyntaxOnly": true,
+        "types": ["node", "mocha"]
+    },
+    "include": [
+        "./**/*.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "downlevelIteration": true,
     "sourceMap": true,
     "strictNullChecks": false,
     "declaration": true,
     "removeComments": true,
-    "target": "es2019",
-    "lib": ["es2019"],
+    "target": "es2025",
+    "erasableSyntaxOnly": true,
+    "types": ["node"],
+    "rootDir": "./src",
     "outDir": "./lib",
-    "moduleResolution": "node",
     "module": "commonjs"
   },
   "include": [


### PR DESCRIPTION
https://www.mongodb.com/community/forums/t/migrate-kerberos-library-off-of-node-bindings/230919

https://jira.mongodb.org/browse/NODE-6591

Following in the footsteps of these efforts